### PR TITLE
Edit tags on post

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -10,7 +10,8 @@ get_all_post_reactions,
 get_all_comments,
 get_all_categories,
 get_all_post_tags, get_posts_by_user, create_category, delete_post, update_post,
-create_subscription, create_multiple_post_tags, delete_multiple_post_tags)
+create_subscription, create_multiple_post_tags,
+delete_multiple_post_tags, get_post_tags_for_single_post)
 
 
 class HandleRequests(BaseHTTPRequestHandler):
@@ -130,7 +131,9 @@ class HandleRequests(BaseHTTPRequestHandler):
                     response = get_posts_by_title(query['title'][0])
                 elif query.get('tag'):
                     response = get_posts_by_tag(query['tag'][0])
-                
+            if resource == 'post_tags':
+                if query.get('post'):
+                    response = get_post_tags_for_single_post(query['post'][0])
                     
             # ( resource, key, value ) = parsed
             # if resource == 'posts':

--- a/request_handler.py
+++ b/request_handler.py
@@ -10,7 +10,7 @@ get_all_post_reactions,
 get_all_comments,
 get_all_categories,
 get_all_post_tags, get_posts_by_user, create_category, delete_post, update_post,
-create_subscription, create_multiple_post_tags)
+create_subscription, create_multiple_post_tags, delete_multiple_post_tags)
 
 
 class HandleRequests(BaseHTTPRequestHandler):
@@ -205,12 +205,18 @@ class HandleRequests(BaseHTTPRequestHandler):
 
     def do_DELETE(self):
         """Handle DELETE Requests"""
-        self._set_headers(204)
+        content_len = int(self.headers.get('content-length', 0))
+        delete_body = json.loads(self.rfile.read(content_len))
+
+        status_code = 204
         (resource, id) = self.parse_url(self.path)
 
         if resource == "posts":
             delete_post(id)
+        if resource == "post_tags":
+            delete_multiple_post_tags(delete_body)
 
+        self._set_headers(status_code)
         self.wfile.write("".encode())
 
 def main():

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -9,7 +9,7 @@ from .reactions_request import get_all_reactions
 from .posts_request import get_all_posts, get_single_post, get_posts_by_user, get_posts_by_category, get_posts_by_title, create_post, delete_post, update_post, get_posts_by_tag
 
 from .post_tags_request import (get_all_post_tags, create_multiple_post_tags,
-                                delete_multiple_post_tags)
+                                delete_multiple_post_tags, get_post_tags_for_single_post)
 
 from .post_reactions_request import get_all_post_reactions
 

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -8,7 +8,8 @@ from .reactions_request import get_all_reactions
 
 from .posts_request import get_all_posts, get_single_post, get_posts_by_user, get_posts_by_category, get_posts_by_title, create_post, delete_post, update_post, get_posts_by_tag
 
-from .post_tags_request import get_all_post_tags, create_multiple_post_tags
+from .post_tags_request import (get_all_post_tags, create_multiple_post_tags,
+                                delete_multiple_post_tags)
 
 from .post_reactions_request import get_all_post_reactions
 

--- a/views/post_tags_request.py
+++ b/views/post_tags_request.py
@@ -65,3 +65,29 @@ def create_multiple_post_tags(post_body):
             posted_tag_relationships.append(new_post_tag)
 
         return json.dumps(posted_tag_relationships)
+
+def delete_multiple_post_tags(id_list):
+    """Delete post-tag relationships from database when editing post"""
+    with sqlite3.connect("./db.sqlite3") as conn:
+        db_cursor = conn.cursor()
+        rows_affected = 0
+
+        for single_id in id_list:
+            db_cursor.execute("""
+            DELETE FROM PostTags
+            WHERE id = ?
+            """, (single_id, ))
+
+            # Were any rows affected?
+            # Did the client send an `id` that exists?
+            rows_affected += db_cursor.rowcount
+
+    result = False
+
+    print("rows affected", rows_affected)
+
+    if rows_affected != 0:
+        # Forces 404 response by main module
+        result = True
+
+    return result

--- a/views/post_tags_request.py
+++ b/views/post_tags_request.py
@@ -37,6 +37,37 @@ def get_all_post_tags():
 
     return post_tags
 
+def get_post_tags_for_single_post(single_post_id):
+    """Retrieve all post_tags for a single post"""
+    with sqlite3.connect("./db.sqlite3") as conn:
+
+        # Initialize the cursor object and access rows by column name
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+
+        # Write the SQL query to get the information you want
+        db_cursor.execute("""
+        SELECT
+            pt.id,
+            pt.post_id,
+            pt.tag_id
+        FROM PostTags pt
+        WHERE pt.post_id = ?
+        """, ( single_post_id, ))
+
+        post_tags = []
+
+        dataset = db_cursor.fetchall()
+
+        for row in dataset:
+            post_tag = PostTag(row['id'], row['post_id'], row['tag_id'])
+
+
+            post_tags.append(post_tag.__dict__)
+
+    return post_tags
+
 def create_multiple_post_tags(post_body):
     """Create one or many postTags to relate a tag to a post when a post is created"""
 


### PR DESCRIPTION
## Changes Made

#### delete_multiple_post_tags function added

- Takes in array of post_tag id's to delete
- counts rows that were deleted
- returns True if rows deleted greater than zero

#### get_post_tags_for_single_post added

- Takes in a selected post id and returns list of post_tag relationships with matching foreign key
- Uses query to get post_tags by post_id: example: `http://localhost:8088/post_tags?post=3`

#### Logic added to doDelete() to handle a request body

- if content length is greater than zero, it will be set as value for delete_body
- else, delete_body defaults to None

#### New endpoint created

- To prevent confusion, all bulk deletes for post_tags will be made to the new endpoint `/post_tags+bulk_delete`
- No id needs to be entered in the url. Instead, an array (or list) of all id's the client wants to remove should be sent in the body of the request. `[1, 2, 3, etc]`

#### Error Handling

- Client has to send body in proper format to perform successful DELETE. The requirements are:
  - Body must be included with request
  - Body must be an array/list of integers
  - Body must have a length greater than zere
  - request must be made to "/post_tags+bulk_delete" endpoint
- If the requirements are not met, the client will get a `400` status code with a response body that says:

  ```
                {
                    "error - bad request": "To  perform a bulk delete operation of post_tags, 
                    please provide an array of the primary keys you would like to delete",
                    "example": [8, 9, 10]
                } 
## My branch
`edit-tags-on-post`
